### PR TITLE
debezium/dbz#1658 JDBC Sink Connector errors when "-infinity" provided for timestamptz column if ...

### DIFF
--- a/agent-summary.md
+++ b/agent-summary.md
@@ -1,0 +1,13 @@
+Fixes `ZonedTimestampType.getQueryBinding()` to always return `cast(? as timestamptz)` so that infinity timestamp values work correctly in multi-record JDBC batches.
+
+- `ZonedTimestampType.getQueryBinding()`: Removed value-dependent branching; the method now unconditionally returns `"cast(? as timestamptz)"`. Previously it returned a plain `?` for non-infinity values, but the SQL template is built from the first record only and reused for all records in a JDBC batch. When the first record had a regular timestamp, subsequent records with `-infinity` or `infinity` failed because the bound `Types.VARCHAR` value could not be implicitly coerced into a `timestamptz` column without an explicit cast.
+
+- `JdbcFieldDescriptor.getQueryBinding()`: Removed the lazily-initialized `queryBinding` cache field. The method now delegates directly to `jdbcType.getQueryBinding(column, schema, value)` on every call. This restores true immutability (consistent with the `@Immutable` annotation) and prevents value-dependent bindings from being locked in on the first call.
+
+- `JdbcSinkInsertModeIT.testInsertModeInfinityValueAsNonFirstRecordInBatch()`: New integration test parameterized over both standard INSERT and UNNEST batch modes. It consumes a two-record batch where the first record holds a normal timestamp and the second holds `-infinity`, then asserts both rows are present in the target table.
+
+## Notes for reviewer
+
+The `cast(? as timestamptz)` binding works for both regular timestamps (bound as `Types.TIMESTAMP_WITH_TIMEZONE` / `OffsetDateTime`) and infinity values (bound as `Types.VARCHAR` / `"-infinity"` / `"infinity"`). PostgreSQL accepts the explicit cast for both cases, so changing from a conditional to an unconditional cast is safe.
+
+The `@Immutable` annotation on `JdbcFieldDescriptor` was already violated by the mutable `queryBinding` cache; removing the field makes the annotation accurate again.

--- a/commit-subject.md
+++ b/commit-subject.md
@@ -1,0 +1,1 @@
+Fix infinity timestamptz binding for non-first records in batch

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampType.java
@@ -27,12 +27,7 @@ public class ZonedTimestampType extends DebeziumZonedTimestampType {
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-
-        if (POSITIVE_INFINITY.equals(value) || NEGATIVE_INFINITY.equals(value)) {
-            return "cast(? as timestamptz)";
-        }
-
-        return super.getQueryBinding(column, schema, value);
+        return "cast(? as timestamptz)";
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/field/JdbcFieldDescriptor.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/field/JdbcFieldDescriptor.java
@@ -22,18 +22,12 @@ import io.debezium.sink.valuebinding.ValueBindDescriptor;
 @Immutable
 public class JdbcFieldDescriptor extends FieldDescriptor {
 
-    // Lazily prepared
-    private String queryBinding;
-
     public JdbcFieldDescriptor(FieldDescriptor fieldDescriptor, boolean isKey) {
         super(fieldDescriptor.getSchema(), fieldDescriptor.getName(), isKey);
     }
 
     public String getQueryBinding(ColumnDescriptor column, Object value, JdbcType jdbcType) {
-        if (queryBinding == null) {
-            queryBinding = jdbcType.getQueryBinding(column, schema, value);
-        }
-        return queryBinding;
+        return jdbcType.getQueryBinding(column, schema, value);
     }
 
     public List<ValueBindDescriptor> bind(int startIndex, Object value, JdbcType jdbcType) {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
@@ -309,6 +309,50 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
 
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-1658")
+    public void testInsertModeInfinityValueAsNonFirstRecordInBatch(SinkRecordFactory factory, PostgresInsertMode insertMode) throws SQLException {
+
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_VALUE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_FIELDS, "id");
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.INSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final Schema zonedTimestampSchema = SchemaBuilder.string()
+                .name("io.debezium.time.ZonedTimestamp")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+
+        // First record has a normal timestamp value
+        final JdbcKafkaSinkRecord normalRecord = factory.createRecordWithSchemaValue(topicName, (byte) 1,
+                List.of("ts"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "2024-01-15T12:00:00Z" }), config);
+
+        // Second record has -infinity; batched together with normalRecord
+        final JdbcKafkaSinkRecord negativeInfinityRecord = factory.createRecordWithSchemaValue(topicName, (byte) 2,
+                List.of("ts"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "-infinity" }), config);
+
+        consume(List.of(normalRecord, negativeInfinityRecord));
+
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(normalRecord));
+        tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(2);
+
+        getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 2);
+    }
+
     private static Schema buildGeoTypeSchema(String type) {
 
         SchemaBuilder schemaBuilder = SchemaBuilder.struct()

--- a/write_files.py
+++ b/write_files.py
@@ -1,0 +1,33 @@
+summary = (
+    "Fixes `ZonedTimestampType.getQueryBinding()` to always return `cast(? as timestamptz)` "
+    "so that infinity timestamp values work correctly in multi-record JDBC batches.\n\n"
+    "- `ZonedTimestampType.getQueryBinding()`: Removed value-dependent branching; the method now "
+    'unconditionally returns `"cast(? as timestamptz)"`. Previously it returned a plain `?` for '
+    "non-infinity values, but the SQL template is built from the first record only and reused for "
+    "all records in a JDBC batch. When the first record had a regular timestamp, subsequent records "
+    "with `-infinity` or `infinity` failed because the bound `Types.VARCHAR` value could not be "
+    "implicitly coerced into a `timestamptz` column without an explicit cast.\n\n"
+    "- `JdbcFieldDescriptor.getQueryBinding()`: Removed the lazily-initialized `queryBinding` cache "
+    "field. The method now delegates directly to `jdbcType.getQueryBinding(column, schema, value)` "
+    "on every call. This restores true immutability (consistent with the `@Immutable` annotation) "
+    "and prevents value-dependent bindings from being locked in on the first call.\n\n"
+    "- `JdbcSinkInsertModeIT.testInsertModeInfinityValueAsNonFirstRecordInBatch()`: New integration "
+    "test parameterized over both standard INSERT and UNNEST batch modes. It consumes a two-record "
+    "batch where the first record holds a normal timestamp and the second holds `-infinity`, then "
+    "asserts both rows are present in the target table.\n\n"
+    "## Notes for reviewer\n\n"
+    "The `cast(? as timestamptz)` binding works for both regular timestamps (bound as "
+    "`Types.TIMESTAMP_WITH_TIMEZONE` / `OffsetDateTime`) and infinity values (bound as "
+    '`Types.VARCHAR` / `"-infinity"` / `"infinity"`). PostgreSQL accepts the explicit cast for '
+    "both cases, so changing from a conditional to an unconditional cast is safe.\n\n"
+    "The `@Immutable` annotation on `JdbcFieldDescriptor` was already violated by the mutable "
+    "`queryBinding` cache; removing the field makes the annotation accurate again.\n"
+)
+
+with open('/tmp/agent-summary.md', 'w') as f:
+    f.write(summary)
+
+with open('/tmp/commit-subject.md', 'w') as f:
+    f.write('Fix infinity timestamptz binding for non-first records in batch\n')
+
+print('Both files written successfully.')


### PR DESCRIPTION
## Description

_(The agent did not provide a written summary; showing the original issue description for reference.)_



## Changes

```
Files changed (vs main):

 agent-summary.md                                   | 13 +++++++
 commit-subject.md                                  |  1 +
 .../jdbc/dialect/postgres/ZonedTimestampType.java  |  7 +---
 .../connector/jdbc/field/JdbcFieldDescriptor.java  |  8 +---
 .../integration/postgres/JdbcSinkInsertModeIT.java | 44 ++++++++++++++++++++++
 write_files.py                                     | 33 ++++++++++++++++
 6 files changed, 93 insertions(+), 13 deletions(-)

Commits:

233fd7a4c7 debezium/dbz#1658 JDBC Sink Connector errors when "-infinity" provided for timestamptz column if ...
```

## PR Checklist
- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

---

🤖 Automated PR generated by the AI agent workflow.