### PR TITLE
debezium/dbz#1658 JDBC Sink Connector errors when "-infinity" provided for timestamptz column if ...

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampType.java
@@ -27,12 +27,12 @@ public class ZonedTimestampType extends DebeziumZonedTimestampType {
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-
-        if (POSITIVE_INFINITY.equals(value) || NEGATIVE_INFINITY.equals(value)) {
-            return "cast(? as timestamptz)";
-        }
-
-        return super.getQueryBinding(column, schema, value);
+        // Always use a cast expression so that infinity string values can be bound correctly
+        // regardless of their position in a batch. When a batch contains a mix of normal
+        // timestamps and infinity values, the SQL template is built from the first record
+        // and reused for all records. Infinity values must be sent as VARCHAR strings
+        // (e.g. "-infinity") and require an explicit CAST to be accepted by PostgreSQL.
+        return "cast(? as timestamptz)";
     }
 
     @Override

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampTypeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ZonedTimestampType}.
+ */
+@Tag("UnitTests")
+class ZonedTimestampTypeTest {
+
+    @Test
+    void testQueryBindingWithNormalTimestampReturnsCastExpression() {
+        final var result = ZonedTimestampType.INSTANCE.getQueryBinding(null, null, "2024-01-15T10:30:00Z");
+        assertThat(result).isEqualTo("cast(? as timestamptz)");
+    }
+
+    @Test
+    void testQueryBindingWithNegativeInfinityReturnsCastExpression() {
+        final var result = ZonedTimestampType.INSTANCE.getQueryBinding(null, null, "-infinity");
+        assertThat(result).isEqualTo("cast(? as timestamptz)");
+    }
+
+    @Test
+    void testQueryBindingWithPositiveInfinityReturnsCastExpression() {
+        final var result = ZonedTimestampType.INSTANCE.getQueryBinding(null, null, "infinity");
+        assertThat(result).isEqualTo("cast(? as timestamptz)");
+    }
+
+    @Test
+    void testQueryBindingWithNullReturnsCastExpression() {
+        final var result = ZonedTimestampType.INSTANCE.getQueryBinding(null, null, null);
+        assertThat(result).isEqualTo("cast(? as timestamptz)");
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
@@ -268,6 +268,52 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
     }
 
     @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-1658")
+    public void testUpsertModeWithInfinityTimestampAsSecondRecordInBatch(SinkRecordFactory factory) throws SQLException {
+
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, "false");
+
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final Schema zonedTimestampSchema = SchemaBuilder.string()
+                .name("io.debezium.time.ZonedTimestamp")
+                .optional()
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+
+        // First record uses a normal timestamp value; this determines the SQL template
+        // used for the entire batch
+        final JdbcKafkaSinkRecord normalRecord = factory.createRecordWithSchemaValue(topicName, (byte) 1,
+                List.of("ts"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "2024-01-15T10:30:00.000Z" }), config);
+
+        // Second record uses -infinity; previously this failed because the SQL template
+        // was built from the first record without the required CAST expression
+        final JdbcKafkaSinkRecord negativeInfinityRecord = factory.createRecordWithSchemaValue(topicName, (byte) 2,
+                List.of("ts"),
+                List.of(zonedTimestampSchema),
+                Arrays.asList(new Object[]{ "-infinity" }), config);
+
+        consume(List.of(normalRecord, negativeInfinityRecord));
+
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTableName(normalRecord));
+        tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(2);
+
+        getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 2);
+    }
+
+    @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
     @FixFor("DBZ-7920")
     public void testInsertModeInsertInfinityValues(SinkRecordFactory factory, PostgresInsertMode insertMode) throws SQLException {


### PR DESCRIPTION
## Description

_(The agent did not provide a written summary; showing the original issue description for reference.)_



## Changes

```
Files changed (vs main):

 .../jdbc/dialect/postgres/ZonedTimestampType.java  | 12 +++---
 .../dialect/postgres/ZonedTimestampTypeTest.java   | 42 ++++++++++++++++++++
 .../integration/postgres/JdbcSinkInsertModeIT.java | 46 ++++++++++++++++++++++
 3 files changed, 94 insertions(+), 6 deletions(-)

Commits:

927c5e8b7e debezium/dbz#1658 JDBC Sink Connector errors when "-infinity" provided for timestamptz column if ...
```

## PR Checklist
- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

---

🤖 Automated PR generated by the AI agent workflow.