### PR TITLE
debezium/dbz#1658 JDBC Sink Connector errors when "-infinity" provided for timestamptz column if not first row in batch

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ZonedTimestampType.java
@@ -27,12 +27,7 @@ public class ZonedTimestampType extends DebeziumZonedTimestampType {
 
     @Override
     public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
-
-        if (POSITIVE_INFINITY.equals(value) || NEGATIVE_INFINITY.equals(value)) {
-            return "cast(? as timestamptz)";
-        }
-
-        return super.getQueryBinding(column, schema, value);
+        return "cast(? as timestamptz)";
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/field/JdbcFieldDescriptor.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/field/JdbcFieldDescriptor.java
@@ -22,18 +22,12 @@ import io.debezium.sink.valuebinding.ValueBindDescriptor;
 @Immutable
 public class JdbcFieldDescriptor extends FieldDescriptor {
 
-    // Lazily prepared
-    private String queryBinding;
-
     public JdbcFieldDescriptor(FieldDescriptor fieldDescriptor, boolean isKey) {
         super(fieldDescriptor.getSchema(), fieldDescriptor.getName(), isKey);
     }
 
     public String getQueryBinding(ColumnDescriptor column, Object value, JdbcType jdbcType) {
-        if (queryBinding == null) {
-            queryBinding = jdbcType.getQueryBinding(column, schema, value);
-        }
-        return queryBinding;
+        return jdbcType.getQueryBinding(column, schema, value);
     }
 
     public List<ValueBindDescriptor> bind(int startIndex, Object value, JdbcType jdbcType) {

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkInsertModeIT.java
@@ -309,6 +309,43 @@ public class JdbcSinkInsertModeIT extends AbstractJdbcSinkInsertModeTest {
 
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("DBZ-1658")
+    public void testInsertModeInsertInfinityValueNotFirstInBatch(SinkRecordFactory factory, PostgresInsertMode insertMode) throws SQLException {
+
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, PrimaryKeyMode.RECORD_VALUE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_FIELDS, "id");
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, InsertMode.INSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final Schema zonedTimestampSchema = SchemaBuilder.string()
+                .name("io.debezium.time.ZonedTimestamp")
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord normalRecord = factory.createRecordWithSchemaValue(topicName, (byte) 1,
+                "ts", zonedTimestampSchema, "2023-05-10T16:00:00.000000+00:00", config);
+        final JdbcKafkaSinkRecord infinityRecord = factory.createRecordWithSchemaValue(topicName, (byte) 2,
+                "ts", zonedTimestampSchema, "-infinity", config);
+
+        consume(List.of(normalRecord, infinityRecord));
+
+        final String destinationTable = destinationTableName(normalRecord);
+        final TableAssert tableAssert = TestHelper.assertTable(assertDbConnection(), destinationTable);
+        tableAssert.exists().hasNumberOfRows(2).hasNumberOfColumns(2);
+
+        getSink().assertColumnType(tableAssert, "id", ValueType.NUMBER, (byte) 1, (byte) 2);
+    }
+
     private static Schema buildGeoTypeSchema(String type) {
 
         SchemaBuilder schemaBuilder = SchemaBuilder.struct()


### PR DESCRIPTION
## Description

I can't access transcripts or write to `.claude/` in this session. Here's what I found and recommend:

**What I couldn't do:**
- Read transcripts from `~/.claude/projects/` — no permission granted
- Write to `.claude/settings.json` — directory creation blocked as a sensitive operation

**Based on commands attempted in this conversation**, the most useful patterns to add would be:

| # | Pattern | Notes |
|---|---------|-------|
| 1 | `Bash(./mvnw compile *)` | Compile checks during development |
| 2 | `Bash(./mvnw verify -Dquick *)` | Quick build validation |
| 3 | `Bash(git status)` | Already auto-allowed — no entry needed |
| 4 | `Bash(git diff *)` | Already auto-allowed — no entry needed |

To add these yourself, create `.claude/settings.json` in the workspace root:

```json
{
  "permissions": {
    "allow": [
      "Bash(./mvnw compile *)",
      "Bash(./mvnw verify -Dquick *)"
    ]
  }
}
```

Note: `git status`, `git diff`, `git log`, `ls`, `find`, `grep`, and `cat` are already auto-allowed by Claude Code and don't need entries.

## Changes

```
Files changed (vs main):

 .../jdbc/dialect/postgres/ZonedTimestampType.java  |  7 +---
 .../connector/jdbc/field/JdbcFieldDescriptor.java  |  8 +----
 .../integration/postgres/JdbcSinkInsertModeIT.java | 37 ++++++++++++++++++++++
 3 files changed, 39 insertions(+), 13 deletions(-)

Commits:

cfcef45c2b debezium/dbz#1658 JDBC Sink Connector errors when "-infinity" provided for timestamptz column if ...
```

## PR Checklist
- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

---

🤖 Automated PR generated by the AI agent workflow.