### PR TITLE
Update to latest Oracle 23.26.x driver

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -444,7 +444,7 @@ jobs:
         - variables:
             ORACLE_VERSION: 23.3.0.0
             ORACLE_REGISTRY: "container-registry.oracle.com/database/free"
-            ORACLE_PROFILE_ARGS: "-Poracle-23 -pl debezium-connector-oracle"
+            ORACLE_PROFILE_ARGS: "-pl debezium-connector-oracle"
             TEST_PROFILE: oracle
 
   ###############################################################################################
@@ -469,7 +469,6 @@ jobs:
         - variables:
             ORACLE_VERSION: 23.26.1
             ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
-            ORACLE_PROFILE_ARGS: "-Poracle-26"
             TEST_PROFILE: oracle
 
   ###############################################################################################
@@ -494,6 +493,6 @@ jobs:
         - variables:
             ORACLE_VERSION: 23.26.1-xs
             ORACLE_REGISTRY: "quay.io/rh_integration/dbz-oracle"
-            ORACLE_PROFILE_ARGS: "-Poracle-26,oracle-xstream"
-            ORACLE_ARG: "-Poracle-xstream,oracle-26"
+            ORACLE_PROFILE_ARGS: "-Poracle-xstream"
+            ORACLE_ARG: "-Poracle-xstream"
             TEST_PROFILE: oracle

--- a/debezium-connector-oracle/README.md
+++ b/debezium-connector-oracle/README.md
@@ -30,7 +30,7 @@ In order to build this connector, the following pre-requisites must be met:
 mvn install:install-file \
   -DgroupId=com.oracle.instantclient \
   -DartifactId=xstreams \
-  -Dversion=21.15.0.0 \
+  -Dversion=23.26.1.0.0 \
   -Dpackaging=jar \
   -Dfile=xstreams.jar
 ```

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -910,33 +910,11 @@
             </properties>
         </profile>
         <profile>
-            <id>oracle-23</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <version.oracle.driver>23.3.0.23.09</version.oracle.driver>
-                <version.oracle.instantclient>23.3.0.0</version.oracle.instantclient>
-            </properties>
-        </profile>
-        <profile>
-            <id>oracle-26</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <version.oracle.driver>23.3.0.23.09</version.oracle.driver>
-                <version.oracle.instantclient>23.3.0.0</version.oracle.instantclient>
-            </properties>
-        </profile>
-        <profile>
             <id>oracle-free</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <version.oracle.driver>23.3.0.23.09</version.oracle.driver>
-                <version.oracle.instantclient>23.3.0.0</version.oracle.instantclient>
                 <oracle.image.name>container-registry.oracle.com/database/free</oracle.image.name>
                 <oracle.image.version>23.26.0.0</oracle.image.version>
             </properties>

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -19,7 +19,7 @@ asciidoc:
     strimzi-version: '0.18.0'
     apicurio-version: '2.6.13.Final'
     db2-version: '11.5.0.0'
-    ojdbc-version: '21.15.0.0'
+    ojdbc-version: '23.26.1.0.0'
     informix-jdbc-version: '4.50.11'
     ifx-changestream-version: '1.1.3'
     min-java-connectors-version: '17'

--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,8 @@
         <version.jt400>11.1</version.jt400> <!-- IBM Toolbox for Java (JT400) for Debezium JDBC connector Db2i dialect -->
         <!-- These two should be aligned by major versions but minor could vary -->
         <!-- Oracle publishes the driver versions more frequently than the instant client -->
-        <version.oracle.driver>21.15.0.0</version.oracle.driver>
-        <version.oracle.instantclient>21.15.0.0</version.oracle.instantclient>
+        <version.oracle.driver>23.26.1.0.0</version.oracle.driver>
+        <version.oracle.instantclient>23.26.1.0.0</version.oracle.instantclient>
 
         <!-- Databases, should align with database drivers -->
         <version.mysql.server>8.2</version.mysql.server>


### PR DESCRIPTION
## Description

Updates the Oracle JDBC driver from version 21.15.0.0 to 23.26.2.0.0 and the Oracle Instant Client from 21.15.0.0 to 23.26.1.0.0, unifying the driver version across all Oracle database version profiles (19, 21, 23, 26).

- **pom.xml** (root): Changed `version.oracle.driver` property from `21.15.0.0` to `23.26.2.0.0` and `version.oracle.instantclient` from `21.15.0.0` to `23.26.1.0.0`. This affects all managed dependencies in the BOM (`ojdbc11`, `orai18n`, `xdb`, `xmlparserv2`, `xstreams`).

- **debezium-connector-oracle/pom.xml**: Removed the `oracle-23` and `oracle-26` Maven profiles, which only contained driver/instantclient version overrides (`23.3.0.23.09` / `23.3.0.0`) that are now redundant. Removed the driver/instantclient overrides from the `oracle-free` profile while keeping its container image properties (`oracle.image.name`, `oracle.image.version`) and build configuration intact.

- **documentation/antora.yml**: Updated the `ojdbc-version` attribute from `21.15.0.0` to `23.26.2.0.0`. This attribute is used in documentation download links for the Oracle JDBC driver.

- **debezium-connector-oracle/README.md**: Updated the `xstreams.jar` manual install example to use version `23.26.1.0.0` (matching the new instant client version).

## Notes for reviewer

- The driver version `23.26.2.0.0` is the latest available on Maven Central for `ojdbc11`, `orai18n`, `xdb`, and `xmlparserv2`. The instant client version `23.26.1.0.0` is the latest available from Oracle's Instant Client distribution.
- The `.packit.yaml` CI configuration references `-Poracle-23` and `-Poracle-26` profiles. Maven silently ignores unknown profiles, so these references are harmless and will use the root POM's driver version as intended.
- The `ORACLE_VERSION` values in `.packit.yaml` refer to database container image versions, not JDBC driver versions, and were not changed.


## Update 1 — 2026-05-13

Addressed reviewer feedback by downgrading the Oracle JDBC driver version from 23.26.2.0.0 to 23.26.1.0.0 in both `pom.xml` and `documentation/antora.yml`, so that the driver and instant client versions are aligned at 23.26.1.0.0.


## Update 2 — 2026-05-13

Addressed reviewer feedback by downgrading the Oracle JDBC driver version from 23.26.2.0.0 to 23.26.1.0.0 in both `pom.xml` and `documentation/antora.yml`, so that the driver and instant client versions are aligned at 23.26.1.0.0.


## Update 3 — 2026-05-13

Addressed reviewer feedback by downgrading the Oracle JDBC driver version from 23.26.2.0.0 to 23.26.1.0.0 in both `pom.xml` and `documentation/antora.yml`, so that the driver and instant client versions are aligned at 23.26.1.0.0.

## Changes

```
Files changed (vs main):

 .packit.yaml                        |  7 +++----
 debezium-connector-oracle/README.md |  2 +-
 debezium-connector-oracle/pom.xml   | 22 ----------------------
 documentation/antora.yml            |  2 +-
 pom.xml                             |  4 ++--
 5 files changed, 7 insertions(+), 30 deletions(-)

Commits:

08a42ab59f debezium/dbz#1837 Remove stale oracle-23/oracle-26 profile refs from .packit.yaml
b5eb2ecde2 debezium/dbz#1837 Align Oracle JDBC driver to 23.26.1.0.0
```
## PR Checklist
- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

---

🤖 Automated PR generated by the AI agent workflow.
